### PR TITLE
Updated regex with Rubocop-friendly syntax

### DIFF
--- a/source/_docs/02-install.md
+++ b/source/_docs/02-install.md
@@ -76,7 +76,7 @@ Make sure the frontend is allowed to connect to ActionCable. You can define the 
 
 ```ruby
 Algolia::Application.configure do
-  config.action_cable.allowed_request_origins = [/http:\/\/*/, /https:\/\/*/]
+  config.action_cable.allowed_request_origins = [%r{http://*}, %r{https://*}]
 end
 ```
 


### PR DESCRIPTION
Updated the `allowed_request_origins` regex to something that Rubocop suggested. In addition to being Rubocop-friendly, I think it reads a little cleaner too. Let me know what you think!

And thanks for your work on debugbar!